### PR TITLE
Feature - wrapperContentWidth: "auto"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 ### Changed
 - Fixed Image component "image" part tailwind class output if not set.
 - Fix Image component responsive output Co-authored-by: goran.alkovic@infinum.com
+- Add "Auto" width to wrapperContent and set is as defaults
 - Updated dependencies.
 
 ## [1.4.6]

--- a/blocks/init/src/Blocks/wrapper/manifest.json
+++ b/blocks/init/src/Blocks/wrapper/manifest.json
@@ -90,7 +90,7 @@
 		"wrapperContentWidth": {
 			"type": "object",
 			"default": {
-				"_default": "full",
+				"_default": "auto",
 				"_desktopFirst": true
 			}
 		},
@@ -290,6 +290,11 @@
 		],
 		"wrapperContentWidth": [
 			{
+				"label": "Auto",
+				"value": "auto",
+				"separator": "below"
+			},
+			{
 				"label": "Full",
 				"value": "full",
 				"separator": "below"
@@ -439,6 +444,7 @@
 			"wrapperContentWidth": {
 				"responsive": true,
 				"twClasses": {
+					"auto": "w-auto",
 					"full": "w-full",
 					"half": "w-1/2",
 					"one-third": "w-1/3",


### PR DESCRIPTION
# Description

This enables the wrapper to respect the alignment set by a parent block e.g. aligning centrally a button within a column.
New default "auto" attribute does not affect the current wrapper behavior
