### PR TITLE
Feature - button type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 - Fixed Image component "image" part tailwind class output if not set.
 - Fix Image component responsive output Co-authored-by: goran.alkovic@infinum.com
 - Add "Auto" width to wrapperContent and set is as defaults
+- Add a buttonType attribute to Button component
 - Updated dependencies.
 
 ## [1.4.6]

--- a/blocks/init/src/Blocks/components/button/button.php
+++ b/blocks/init/src/Blocks/components/button/button.php
@@ -19,6 +19,7 @@ if (!$buttonUse) {
 $additionalClass = $attributes['additionalClass'] ?? '';
 $additionalAttributes = $attributes['additionalAttributes'] ?? [];
 $buttonId = Helpers::checkAttr('buttonId', $attributes, $manifest);
+$buttonType = Helpers::checkAttr('buttonType', $attributes, $manifest);
 
 $buttonUrl = Helpers::checkAttr('buttonUrl', $attributes, $manifest);
 $buttonIsNewTab = Helpers::checkAttr('buttonIsNewTab', $attributes, $manifest);
@@ -60,8 +61,8 @@ $buttonAttrs['class'] = Helpers::tailwindClasses('base', $attributes, $manifest,
 
 $buttonTag = !empty($buttonUrl) ? 'a' : 'button';
 
-if (empty($buttonUrl)) {
-	$buttonAttrs['type'] = Helpers::checkAttr('buttonType', $attributes, $manifest);
+if (empty($buttonUrl) && !empty($buttonType)) {
+	$buttonAttrs['type'] = $buttonType;
 }
 ?>
 

--- a/blocks/init/src/Blocks/components/button/button.php
+++ b/blocks/init/src/Blocks/components/button/button.php
@@ -59,6 +59,10 @@ if (!empty($buttonAriaLabel)) {
 $buttonAttrs['class'] = Helpers::tailwindClasses('base', $attributes, $manifest, 'button', $additionalClass);
 
 $buttonTag = !empty($buttonUrl) ? 'a' : 'button';
+
+if (empty($buttonUrl)) {
+	$buttonAttrs['type'] = Helpers::checkAttr('buttonType', $attributes, $manifest);
+}
 ?>
 
 <<?php echo $buttonTag; // phpcs:ignore Eightshift.Security.HelpersEscape.OutputNotEscaped ?>

--- a/blocks/init/src/Blocks/components/button/manifest.json
+++ b/blocks/init/src/Blocks/components/button/manifest.json
@@ -20,6 +20,10 @@
 		"buttonId": {
 			"type": "string"
 		},
+		"buttonType": {
+			"type": "string",
+			"default": "button"
+		},
 		"buttonColor": {
 			"type": "string",
 			"default": "navy-500"

--- a/blocks/init/src/Blocks/components/button/manifest.json
+++ b/blocks/init/src/Blocks/components/button/manifest.json
@@ -22,7 +22,7 @@
 		},
 		"buttonType": {
 			"type": "string",
-			"default": "button"
+			"default": ""
 		},
 		"buttonColor": {
 			"type": "string",


### PR DESCRIPTION
# Description

Enables setting a button type as 'submit', any other viable option or a default 'button' if the Button is not a link.

Use-case: using various buttons in a form without implicitly having them as submit type